### PR TITLE
Fix cross-platform build issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "tailwindcss": "^3.4.0"
       },
       "devDependencies": {
-        "@next/swc-linux-x64-gnu": "^14.0.0",
         "@types/node": "^20.0.0",
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
@@ -553,22 +552,6 @@
       ],
       "license": "MIT",
       "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.2.30",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.30.tgz",
-      "integrity": "sha512-8Ly7okjssLuBoe8qaRCcjGtcMsv79hwzn/63wNeIkzJVFVX06h5S737XNr7DZwlsbTBDOyI6qbL2BJB5n6TV/w==",
-      "cpu": [
-        "x64"
-      ],
-      "devOptional": true,
-      "license": "MIT",
       "os": [
         "linux"
       ],
@@ -4402,7 +4385,6 @@
         "@next/swc-darwin-x64": "14.2.30",
         "@next/swc-linux-arm64-gnu": "14.2.30",
         "@next/swc-linux-arm64-musl": "14.2.30",
-        "@next/swc-linux-x64-gnu": "14.2.30",
         "@next/swc-linux-x64-musl": "14.2.30",
         "@next/swc-win32-arm64-msvc": "14.2.30",
         "@next/swc-win32-ia32-msvc": "14.2.30",
@@ -7414,12 +7396,6 @@
       "integrity": "sha512-8GkNA+sLclQyxgzCDs2/2GSwBc92QLMrmYAmoP2xehe5MUKBLB2cgo34Yu242L1siSkwQkiV4YLdCnjwc/Micw==",
       "optional": true
     },
-    "@next/swc-linux-x64-gnu": {
-      "version": "14.2.30",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.30.tgz",
-      "integrity": "sha512-8Ly7okjssLuBoe8qaRCcjGtcMsv79hwzn/63wNeIkzJVFVX06h5S737XNr7DZwlsbTBDOyI6qbL2BJB5n6TV/w==",
-      "devOptional": true
-    },
     "@next/swc-linux-x64-musl": {
       "version": "14.2.30",
       "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.30.tgz",
@@ -9880,7 +9856,6 @@
         "@next/swc-darwin-x64": "14.2.30",
         "@next/swc-linux-arm64-gnu": "14.2.30",
         "@next/swc-linux-arm64-musl": "14.2.30",
-        "@next/swc-linux-x64-gnu": "14.2.30",
         "@next/swc-linux-x64-musl": "14.2.30",
         "@next/swc-win32-arm64-msvc": "14.2.30",
         "@next/swc-win32-ia32-msvc": "14.2.30",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "@types/react-dom": "^18.2.0",
     "typescript": "^5.3.0",
     "eslint": "^8.0.0",
-    "eslint-config-next": "^14.0.0",
-    "@next/swc-linux-x64-gnu": "^14.0.0"
+    "eslint-config-next": "^14.0.0"
   },
   "engines": {
     "node": ">=18.x"


### PR DESCRIPTION
## Summary
- remove @next/swc-linux-x64-gnu from dev deps to allow building on non-Linux OS

## Testing
- `npm run lint` *(fails: prompts for setup)*
- `npm run build` *(fails: ENETUNREACH fetch errors while patching lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_684b599fa330832db085d85660f09a0c